### PR TITLE
Update github-actions-ec2.yml

### DIFF
--- a/.github/workflows/github-actions-ec2.yml
+++ b/.github/workflows/github-actions-ec2.yml
@@ -35,4 +35,4 @@ jobs:
             sudo systemctl start apache2
             sudo systemctl enable apache2
             cd home
-            sudo mv * /var/www/html
+            sudo cp -- !(README.md) /var/www/html


### PR DESCRIPTION
Using cp instead of mv makes sure that there is a copy of files present. The -- flag tells the mv command to treat the next argument as the destination directory, rather than a source file. The !(README.md) expression is a negation pattern that matches all files except README.md